### PR TITLE
Option to start minimized to system tray

### DIFF
--- a/resources/ui/SettingsWindow.ui
+++ b/resources/ui/SettingsWindow.ui
@@ -112,6 +112,20 @@
             <property name="position">4</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkCheckButton" id="check_start_minimized">
+            <property name="label" translatable="yes">Start minimized to tray</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
       </object>
     </child>
   </template>

--- a/src/Config.vala
+++ b/src/Config.vala
@@ -8,6 +8,7 @@ namespace Cryptor {
         public bool autosave_on_quit { get; set; }
         public bool show_tray_icon { get; set; }
         public bool send_to_tray { get; set; }
+        public bool start_minimized { get; set; }
 
         public Gee.ArrayList<Vault> vaults { get; set; }
 
@@ -17,6 +18,7 @@ namespace Cryptor {
             autosave_on_quit = true;
             show_tray_icon = false;
             send_to_tray = false;
+            start_minimized = false;
             vaults = new Gee.ArrayList<Vault> ();
         }
 

--- a/src/CryptorApp.vala
+++ b/src/CryptorApp.vala
@@ -14,7 +14,7 @@ namespace Cryptor {
 
         protected override void activate () {
             var win = new UI.CryptorWindow (this);
-            win.show_all ();
+            win.show_or_not_show ();
         }
 
         public static int main (string[] args) {

--- a/src/ui/CryptorWindow.vala
+++ b/src/ui/CryptorWindow.vala
@@ -57,6 +57,10 @@ namespace Cryptor.UI {
             this.delete_event.connect (save_before_quit);
 
             show_tray_icon ();
+
+            if (config.start_minimized && w != null && tray != null) {
+                this.hide ();
+            }
         }
 
         [GtkCallback]

--- a/src/ui/CryptorWindow.vala
+++ b/src/ui/CryptorWindow.vala
@@ -57,9 +57,13 @@ namespace Cryptor.UI {
             this.delete_event.connect (save_before_quit);
 
             show_tray_icon ();
+        }
 
+        public void show_or_not_show () {
             if (config.start_minimized && tray != null) {
                 this.hide ();
+            } else {
+                this.show_all ();
             }
         }
 

--- a/src/ui/CryptorWindow.vala
+++ b/src/ui/CryptorWindow.vala
@@ -58,7 +58,7 @@ namespace Cryptor.UI {
 
             show_tray_icon ();
 
-            if (config.start_minimized && w != null && tray != null) {
+            if (config.start_minimized && tray != null) {
                 this.hide ();
             }
         }

--- a/src/ui/SettingsWindow.vala
+++ b/src/ui/SettingsWindow.vala
@@ -32,7 +32,7 @@ namespace Cryptor.UI {
             check_autosave.active = config.autosave_on_quit;
             check_show_tray.active = config.show_tray_icon;
             check_send_to_tray.active = config.send_to_tray;
-            check_start_minimized = config.start_minimized;
+            check_start_minimized.active = config.start_minimized;
             prev_send_to_tray = config.send_to_tray;
             prev_start_minimized = config.start_minimized;
         }

--- a/src/ui/SettingsWindow.vala
+++ b/src/ui/SettingsWindow.vala
@@ -19,6 +19,8 @@ namespace Cryptor.UI {
         [GtkChild]
         private unowned CheckButton check_send_to_tray;
 
+        [GtkChild]
+        private unowned CheckButton check_start_minimized;
 
         public SettingsWindow (Window parent, Config config) {
             Object (
@@ -29,7 +31,9 @@ namespace Cryptor.UI {
             check_autosave.active = config.autosave_on_quit;
             check_show_tray.active = config.show_tray_icon;
             check_send_to_tray.active = config.send_to_tray;
+            check_start_minimized = config.start_minimized;
             prev_send_to_tray = config.send_to_tray;
+            prev_start_minimized = config.start_minimized;
         }
 
         [GtkCallback]
@@ -38,6 +42,7 @@ namespace Cryptor.UI {
             config.autosave_on_quit = check_autosave.active;
             config.show_tray_icon = check_show_tray.active;
             config.send_to_tray = check_send_to_tray.active;
+            config.start_minimized = check_start_minimized.active;
             config.changes_made = true;
             this.close ();
         }
@@ -52,9 +57,13 @@ namespace Cryptor.UI {
             if (cb.active) {
                 check_send_to_tray.sensitive = true;
                 check_send_to_tray.active = prev_send_to_tray;
+                check_start_minimized.sensitive = true;
+                check_start_minimized.active = prev_start_minimized;
             } else {
                 check_send_to_tray.active = false;
                 check_send_to_tray.sensitive = false;
+                check_start_minimized.active = false;
+                check_start_minimized.sensitive = false;
             }
         }
     }

--- a/src/ui/SettingsWindow.vala
+++ b/src/ui/SettingsWindow.vala
@@ -6,6 +6,7 @@ namespace Cryptor.UI {
     public class SettingsWindow : Dialog {
         private Config config;
         bool prev_send_to_tray;
+        bool prev_start_minimized;
 
         [GtkChild]
         private unowned CheckButton check_unmount;


### PR DESCRIPTION
With "system tray icon" and "close to the tray" options the only thing left is an option to "start minimized to system tray" for this tool to be put into system's startup and to be persistent in background. This PR implements that option.