### PR TITLE
Config options to unmount all vaults on screen lock and system sleep

### DIFF
--- a/resources/ui/SettingsWindow.ui
+++ b/resources/ui/SettingsWindow.ui
@@ -70,6 +70,34 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="check_unmount2">
+            <property name="label" translatable="yes">Unmount vaults on system sleep</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="check_unmount3">
+            <property name="label" translatable="yes">Unmount vaults on screen lock</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkCheckButton" id="check_autosave">
             <property name="label" translatable="yes">Autosave configuration file on quit</property>
             <property name="visible">True</property>
@@ -80,7 +108,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -95,7 +123,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -109,7 +137,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -123,7 +151,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
       </object>

--- a/src/Config.vala
+++ b/src/Config.vala
@@ -5,6 +5,8 @@ namespace Cryptor {
         public bool changes_made;
 
         public bool umount_on_quit { get; set; }
+        public bool unmount_on_sleep { get; set; }
+        public bool unmount_on_lock { get; set; }
         public bool autosave_on_quit { get; set; }
         public bool show_tray_icon { get; set; }
         public bool send_to_tray { get; set; }
@@ -15,6 +17,8 @@ namespace Cryptor {
         public Config () {
             changes_made = false;
             umount_on_quit = true;
+            unmount_on_sleep = false;
+            unmount_on_lock = false;
             autosave_on_quit = true;
             show_tray_icon = false;
             send_to_tray = false;

--- a/src/ui/CryptorWindow.vala
+++ b/src/ui/CryptorWindow.vala
@@ -437,7 +437,7 @@ namespace Cryptor.UI {
                 return true;
             }
             if (config.umount_on_quit) {
-                this.unmount_all ();
+                unmount_all ();
             }
             if (config.autosave_on_quit) {
                 if (config_path != null && config_path != "") {

--- a/src/ui/CryptorWindow.vala
+++ b/src/ui/CryptorWindow.vala
@@ -94,7 +94,6 @@ namespace Cryptor.UI {
                     }
                 });
             } catch (Error e) {
-                warning (e.message);
             }
         }
 

--- a/src/ui/CryptorWindow.vala
+++ b/src/ui/CryptorWindow.vala
@@ -12,9 +12,7 @@ namespace Cryptor.UI {
 
     [DBus (name = "org.freedesktop.login1.Session")]
     public interface Session : Object {
-        public abstract void SetIdleHint(bool hint) throws GLib.Error;
         public abstract signal void Lock();
-        public abstract signal void Unlock();
     }
 
     [GtkTemplate (ui = "/org/moson/cryptor/ui/CryptorWindow.ui")]
@@ -90,7 +88,7 @@ namespace Cryptor.UI {
                     "org.freedesktop.login1",
                     this.logind.GetSession(Environment.get_variable("XDG_SESSION_ID"))
                 );
-			    session.Lock.connect(() => {
+                session.Lock.connect(() => {
                     if (config.unmount_on_lock) {
                         unmount_all ();
                     }

--- a/src/ui/CryptorWindow.vala
+++ b/src/ui/CryptorWindow.vala
@@ -3,10 +3,26 @@ using Cryptor.Data;
 using GLib;
 
 namespace Cryptor.UI {
+
+    [DBus (name = "org.freedesktop.login1.Manager")]
+    public interface logindInterface : Object {
+        public abstract string GetSession(string id) throws GLib.Error;
+        public signal void prepare_for_sleep (bool about_to_suspend);
+    }
+
+    [DBus (name = "org.freedesktop.login1.Session")]
+    public interface Session : Object {
+        public abstract void SetIdleHint(bool hint) throws GLib.Error;
+        public abstract signal void Lock();
+        public abstract signal void Unlock();
+    }
+
     [GtkTemplate (ui = "/org/moson/cryptor/ui/CryptorWindow.ui")]
     public class CryptorWindow : ApplicationWindow {
         private Config config;
         private StatusIcon ? tray;
+        private logindInterface? logind;
+        private Session? session;
         private string ? _config_path;
         private string ? config_path {
             get {
@@ -57,6 +73,31 @@ namespace Cryptor.UI {
             }
             this.delete_event.connect (save_before_quit);
             show_tray_icon ();
+
+            try {
+                logind = Bus.get_proxy_sync(
+                    BusType.SYSTEM,
+                    "org.freedesktop.login1",
+                    "/org/freedesktop/login1"
+                );
+                logind.prepare_for_sleep.connect ((about_to_suspend) => {
+                    if (about_to_suspend && config.unmount_on_sleep) {
+                        unmount_all ();
+                    }
+                });
+                session = Bus.get_proxy_sync(
+                    BusType.SYSTEM,
+                    "org.freedesktop.login1",
+                    this.logind.GetSession(Environment.get_variable("XDG_SESSION_ID"))
+                );
+			    session.Lock.connect(() => {
+                    if (config.unmount_on_lock) {
+                        unmount_all ();
+                    }
+                });
+            } catch (Error e) {
+                warning (e.message);
+            }
         }
 
         public void show_or_not_show () {
@@ -379,20 +420,24 @@ namespace Cryptor.UI {
             }
         }
 
+        private void unmount_all () {
+            foreach (var vault in config.vaults) {
+                if (vault.is_mounted) {
+                    try {
+                        Gocrypt.unmount_vault (vault.mount_point);
+                    } catch (Error e) {
+                    }
+                }
+            }
+        }
+
         private bool save_before_quit (Widget ? w, Gdk.EventAny ? ev) {
             if (config.send_to_tray && w != null && tray != null) {
                 this.hide ();
                 return true;
             }
             if (config.umount_on_quit) {
-                foreach (var vault in config.vaults) {
-                    if (vault.is_mounted) {
-                        try {
-                            Gocrypt.unmount_vault (vault.mount_point);
-                        } catch (Error e) {
-                        }
-                    }
-                }
+                this.unmount_all ();
             }
             if (config.autosave_on_quit) {
                 if (config_path != null && config_path != "") {

--- a/src/ui/SettingsWindow.vala
+++ b/src/ui/SettingsWindow.vala
@@ -12,6 +12,12 @@ namespace Cryptor.UI {
         private unowned CheckButton check_unmount;
 
         [GtkChild]
+        private unowned CheckButton check_unmount2;
+
+        [GtkChild]
+        private unowned CheckButton check_unmount3;
+
+        [GtkChild]
         private unowned CheckButton check_autosave;
 
         [GtkChild]
@@ -29,6 +35,8 @@ namespace Cryptor.UI {
             );
             this.config = config;
             check_unmount.active = config.umount_on_quit;
+            check_unmount2.active = config.unmount_on_sleep;
+            check_unmount3.active = config.unmount_on_lock;
             check_autosave.active = config.autosave_on_quit;
             check_show_tray.active = config.show_tray_icon;
             check_send_to_tray.active = config.send_to_tray;
@@ -40,6 +48,8 @@ namespace Cryptor.UI {
         [GtkCallback]
         private void on_save_settings_clicked (Button bt) {
             config.umount_on_quit = check_unmount.active;
+            config.unmount_on_sleep = check_unmount2.active;
+            config.unmount_on_lock = check_unmount3.active;
             config.autosave_on_quit = check_autosave.active;
             config.show_tray_icon = check_show_tray.active;
             config.send_to_tray = check_send_to_tray.active;


### PR DESCRIPTION
Another little security & QOL improvement - two new config options:

- Unmount vaults on system sleep
- Unmount vaults on screen lock

Implemented with DBus signals listeners. Tested in Debian/XFCE but should work in most DE's.